### PR TITLE
(Bug Repaired) Moved Init() into created()

### DIFF
--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -25,11 +25,13 @@
 
 <script>
 import { Players, PictureDeck, CurrentPicture, Init } from "../models/Game";
-Init();
+
 
 export default {
   name: 'Home',
-
+  created(){
+    Init();
+  },
   data:()=>({
     Players,
     PictureDeck,


### PR DESCRIPTION
Init() will now only execute upon the opening of the Game view.

This change needed to be made as it caused the frontend of WDYM to completely malfunction and display a blank white page.

Bug discovered by: Engr. Lorenzo Galante
Bug fixed by: Rabbi Moshe Plotkin