### PR TITLE
Fix bug with v-binding and Init( )

### DIFF
--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -11,20 +11,20 @@
       <div class="card">
       <div class="card-content">
         <ul>
-          <li v-for="player in Players" :key="player.Name">
+          <li v-for="player in Game.Players" :key="player.Name">
             {{player.Name}} {{player.Score}}
           </li>
         </ul>
       </div>
 
-      <img :src="CurrentPicture"  class="card-image"/>
+      <img :src="Game.CurrentPicture"  class="card-image"/>
     </div>
 
   </div>
 </template>
 
 <script>
-import { Players, PictureDeck, CurrentPicture, Init } from "../models/Game";
+import * as Game from "../models/Game";
 
 
 export default {
@@ -33,13 +33,8 @@ export default {
     Init();
   },
   data:()=>({
-    Players,
-    PictureDeck,
-    CurrentPicture
-  }),
-  components: {
-    
-  }
+    Game
+  })
 }
 </script>
 


### PR DESCRIPTION
When we moved Init( ) into created( ), this caused an issue with some of the attributes involving v-binding; for example, we originally had <img :src="CurrentPicture" />to display our card images for our game. After moving Init( ) into created( ), that image was no longer visible on the DOM. 
To fix this, Rabbi Plotkin imported a reference to the Game.js file rather than the named export constants from said file. We then use the reference called Game when necessary.